### PR TITLE
Specified charset-normalizer version to avod errors

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
+charset-normalizer==2.1.0
 boto3
 certbot
 certbot-route53


### PR DESCRIPTION
Fixing compatility issues with latest AWS runtimes

Latest charset-normalizer causes following error running the function
`{"errorMessage": "Unable to import module 'main': cannot import name 'is_arabic' from 'charset_normalizer.utils' (/var/task/charset_normalizer/utils.py)", "errorType": "Runtime.ImportModuleError", "requestId": "c87d7915-ee68-4542-9cab-fc0c52020045", "stackTrace": []}`


